### PR TITLE
aniverasaryとrenderでもエラー対策

### DIFF
--- a/app/controllers/anniversaries_controller.rb
+++ b/app/controllers/anniversaries_controller.rb
@@ -36,7 +36,7 @@ class AnniversariesController < ApplicationController
     def destroy
         anniversary = current_user.anniversaries.find(params[:id])
         anniversary.destroy!
-        redirect_to anniversary_path, success: "success"
+        redirect_to anniversaries_path, success: "success"
     end
 
 


### PR DESCRIPTION
# 概要
デプロイ先でanniversary#destroyを実行したところ、削除した後にエラーが発生していたため解消をした。

# 内容
デプロイ先でanniversary#destroyを実行したところ、削除した後にindexのviewにする予定だったが、showをさがてしまっていたため、controller の遷移先のURL を変更しました。