### PR TITLE
renderの警告を消すために編集

### DIFF
--- a/app/controllers/anniversaries_controller.rb
+++ b/app/controllers/anniversaries_controller.rb
@@ -15,7 +15,7 @@ class AnniversariesController < ApplicationController
             redirect_to anniversaries_path ,success: 'good'
         else
         flash.now[:danger] = 'failure try again' 
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
         end
     end
 
@@ -30,7 +30,7 @@ class AnniversariesController < ApplicationController
             redirect_to anniversaries_path,success: "suceess"
         else
             flash.now[:danger] = "danger"
-            render :edit, status: :unprocessable_entity
+            render :edit, status: :unprocessable_content
         end
     end
     def destroy

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -15,7 +15,7 @@ class PartnersController < ApplicationController
             redirect_to partner_path, success: "OK"
         else
             flash.now[:danger] = "out"
-            render :new, status: :unprocessable_entity
+            render :new, status: :unprocessable_content
         end
     end
 
@@ -30,7 +30,7 @@ class PartnersController < ApplicationController
             redirect_to partner_path,success: "suceess"
         else
             flash.now[:danger] = "danger"
-            render :edit, status: :unprocessable_entity
+            render :edit, status: :unprocessable_content
         end
 
     end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -302,7 +302,7 @@ Devise.setup do |config|
   # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
   # these new defaults that match Hotwire/Turbo behavior.
   # Note: These might become the new default in future versions of Devise.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> Configuration for :registerable


### PR DESCRIPTION
# 概要　
render上に警告が出ていたためファイルの編集

# 内容
````
warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
````
上記をもとに、config/initializer/deviseとanniversary(create/update)とpartner(create/update)の「unprocessable_entity」を
「:unprocessable_content 」に変更