### PR TITLE
destroy訂正

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,10 @@
 
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
-
+  def destroy
+    reset_session
+    redirect_to root_path, info: "ログアウトしました"
+  end
   # GET /resource/sign_in
   # def new
   #   super
@@ -18,7 +21,11 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
+#  
+  def after_sign_out_path_for(_resource_or_scope)
+    root_path
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -29,7 +29,7 @@
         <%= link_to "ホーム", user_root_path, {class: "navbar-brand"}%>
         <!-- link_to は基本「最後に options を1つ」なので、data: と class: を 同じハッシュにまとめる必要があります。 -->
         <%= link_to "ログアウト",
-        destroy_user_session_path,
+        logout_path,
         class: "navbar-brand",
         data: { turbo_method: :delete } %>
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,13 @@ Rails.application.routes.draw do
   end
 
 # LINE ログインの準備ができたらOFFに
-  devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
+  # devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
+
+
+  devise_for :users, controllers: {
+    sessions: "users/sessions",
+    omniauth_callbacks: "users/omniauth_callbacks"
+  }
 
   devise_scope :user do
     delete "logout", to: "devise/sessions#destroy", as: :logout


### PR DESCRIPTION
# 概要
renderでのエラー発生のため訂正( ActionView::Template::Error)
# 内容
- routes にsessionの追加
- sessionコントローラーにdestroyとサインアウト後のカスタムメソッドafter_sign_out_path_forの追加
- viewログインをlogout_pathに向くように