### PR TITLE
rememberable削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
   validates :provider, uniqueness: { scope: :uid }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise  :rememberable,:omniauthable, omniauth_providers: [:line]
+  devise  :omniauthable, omniauth_providers: [:line]
 
   has_many :anniversaries, dependent: :destroy
   has_one :partner, dependent: :destroy


### PR DESCRIPTION
# 概要
devise#rememberable削除
# 内容
user.rb内のdevise#rememberableを削除（本番でも実装しないと決めたため）