### PR TITLE
プログレスバーと削除モーダルの実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -179,3 +179,27 @@ section {
   // progress {
   //   accent-color: hsla(180,30%,30%,.5);
   // }
+
+    /* モーダルのスタイル */
+    .modal {
+      display: none;
+      position: fixed;
+      z-index: 999;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+  
+    .modal-content {
+      background-color: #fff;
+      margin: 200px auto;
+      padding: 20px;
+      width: 300px;
+      text-align: center;
+    }
+  
+    .modal-buttons {
+      margin-top: 20px;
+    }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 
 // how_toshowのselect-optionの画面遷移用
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("turbo:load", () => {
     const selectbox = document.querySelector(".how_to_items");
     const searchKey = "itemId";
   
@@ -82,3 +82,21 @@ const showElements = () => {
 
 window.addEventListener("load", showElements);
 window.addEventListener("scroll", showElements);
+
+
+
+// モーダル
+   document.addEventListener("turbo:load", function() {
+    const deleteBtn = document.getElementById("delete-btn");
+    const modal = document.getElementById("confirmation-modal");
+    const confirmNoBtn = document.getElementById("confirm-no");
+  
+    deleteBtn.addEventListener("click", function(e) {
+      e.preventDefault();
+      modal.style.display = "block";
+    });
+  
+    confirmNoBtn.addEventListener("click", function() {
+      modal.style.display = "none";
+    });
+  }); 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -65,18 +65,16 @@ class Partner < ApplicationRecord
       end
 
       def change_to_progress_bar_value
-        # attributes.delete_if { |k, v| v.blank? }.count
         attrs = attributes.except("id", "created_at", "updated_at", "user_id")
-        attrssize = attrs.size 
+        attrssize = attrs.size
 
         attrs2 = attrs.delete_if { |k, v| v.blank? }
         attrs2size = attrs2.size
-      
-        ((attrs2size.to_f / attrssize) * 100).round
 
+        ((attrs2size.to_f / attrssize) * 100).round
       end
 
-      def progress_bar_color 
+      def progress_bar_color
         value = change_to_progress_bar_value
 
         return "text-bg-success" if value >= 80
@@ -105,7 +103,7 @@ class Partner < ApplicationRecord
              .reject(&:blank?)
       end
 
-      # def change_to_progress_bar_value
-      #   attributes.delete_if { |k, v| v.blank? }
-      # end
+  # def change_to_progress_bar_value
+  #   attributes.delete_if { |k, v| v.blank? }
+  # end
 end

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -40,18 +40,22 @@
   
               <div class="mt-3">
                 <%= link_to "編集", edit_partner_path %>
-                <%= link_to "削除", partner_path, data: { turbo_method: :delete } %>
+                <!-- <button id="delete-btn">削除</button> -->
+                <%= link_to "削除", "#", id: "delete-btn" %>
               </div>
             </div>
           </article>
+            <!-- 確認ポップアップ用のモーダル -->
+            <%= render "shared/confirm_delete_modal"%>
+
         <% else %>
           <div>
             <p>相手が見つかっていません</p>
             <%= link_to "見つけた", new_partner_path %>
           </div>
         <% end %>
-  
       </div>
     </div>
   </div>
   
+

--- a/app/views/shared/_confirm_delete_modal.html.erb
+++ b/app/views/shared/_confirm_delete_modal.html.erb
@@ -1,0 +1,10 @@
+<div id="confirmation-modal" class="modal">
+    <div class="modal-content">
+      <p>大切な人の情報をなくしてもいいですか？</p>
+      <div class="modal-buttons">
+        <button id="confirm-yes"><%= link_to "はい", partner_path, data: { turbo_method: :delete }, id: "confirm-yes" %>
+        </button>
+        <button id="confirm-no">いいえ</button>
+      </div>
+    </div>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
     end
   end
   # has_oneなのでresorce
-  resource :partner 
+  resource :partner
   resources :gift_suggestions, only: %i[ index new create destroy]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?


### PR DESCRIPTION
# 概要
パートナー画面にプログレスバーと削除した時に確認モーダルの追加
# 内容
- プログレスバーのためのvalueを保持できるように
  - app/controllers/partners_controller.rbを編集
- パートナーを削除する際に確認用モーダル処理のためのJSコードを追加
  - app/javascript/application.jsを編集
- プログレスバーの値と値によって色が変わるように処理を追加
  - app/models/partner.rbを編集
- プログレスバーとモーダルが表示されるようにした
  - app/views/partners/show.html.erbを編集
-  モーダルを別ファイルに記載 
  - app/views/shared/_confirm_delete_modal.html.erb作成、編集
-  モーダル用の見た目を変更 
- app/assets/stylesheets/application.bootstrap.scss変種

# 動作確認
- プログレスバーが表示
- 値によってバーが変化し、色も変化
- パートナーを削除すると、削除確認モーダルが表示され、「はい」と押すと削除
- 「いいえ」と押すと、削除されない